### PR TITLE
Add Beaker tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.swp
 *.vim
+log/
+.bundle/
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 log/
 .bundle/
 vendor/
+.vagrant/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,5 @@ MethodLength:
   Max: 20
 ClassLength:
   Max: 120
+Metrics/LineLength:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :test do
   gem 'puppet', '~> 3.7.0'
   gem 'puppetlabs_spec_helper'
   gem 'rubocop'
+  gem 'beaker-rspec'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,71 +2,290 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.2.8)
+    activesupport (4.2.3)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.3.8)
     ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
+    autoparse (0.3.3)
+      addressable (>= 2.3.1)
+      extlib (>= 0.9.15)
+      multi_json (>= 1.0.0)
+    aws-sdk (1.64.0)
+      aws-sdk-v1 (= 1.64.0)
+    aws-sdk-v1 (1.64.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+    beaker (2.18.3)
+      aws-sdk (~> 1.57)
+      docker-api
+      fission (~> 0.4)
+      fog (~> 1.25)
+      google-api-client (~> 0.8)
+      hocon (~> 0.1)
+      inifile (~> 2.0)
+      json (~> 1.8)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 2.9)
+      open_uri_redirections (~> 0.2.1)
+      rbvmomi (~> 1.8)
+      rsync (~> 1.0.9)
+      unf (~> 0.1)
+    beaker-rspec (5.2.0)
+      beaker (~> 2.0)
+      rspec
+      serverspec (~> 2)
+      specinfra (~> 2)
+    builder (3.2.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    facter (2.4.1)
+    docker-api (1.22.1)
+      excon (>= 0.38.0)
+      json
+    excon (0.45.4)
+    extlib (0.9.16)
+    facter (2.4.4)
       CFPropertyList (~> 2.2.6)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.32.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.32)
+      fog-ecloud (= 0.1.1)
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.7.3)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.8.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.32.0)
+      builder
+      excon (~> 0.45)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-ecloud (0.1.1)
+      fog-core
+      fog-xml
+    fog-google (0.0.7)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.5)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.0.1)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.7)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    google-api-client (0.8.6)
+      activesupport (>= 3.2)
+      addressable (~> 2.3)
+      autoparse (~> 0.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      googleauth (~> 0.3)
+      launchy (~> 2.4)
+      multi_json (~> 1.10)
+      retriable (~> 1.4)
+      signet (~> 0.6)
+    googleauth (0.4.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (= 1.11)
+      signet (~> 0.6)
     hiera (1.3.4)
       json_pure
+    hocon (0.9.3)
+    i18n (0.7.0)
+    inflecto (0.0.2)
+    inifile (2.0.2)
+    ipaddress (0.8.0)
+    json (1.8.3)
     json_pure (1.8.2)
+    jwt (1.5.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    little-plugger (1.1.3)
+    logging (2.0.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    memoist (0.12.0)
     metaclass (0.0.4)
     method_source (0.8.2)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
+    minitest (5.7.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    parser (2.2.0.3)
+    multi_json (1.11.0)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    net-telnet (0.1.1)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    open_uri_redirections (0.2.1)
+    parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
-    powerpack (0.1.0)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    puppet (3.7.4)
+    puppet (3.7.5)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
     puppet-lint (1.1.0)
-    puppet-syntax (1.4.1)
+    puppet-syntax (2.0.0)
       rake
-    puppetlabs_spec_helper (0.8.2)
+    puppetlabs_spec_helper (0.10.3)
       mocha
       puppet-lint
       puppet-syntax
       rake
-      rspec
       rspec-puppet
     rainbow (2.0.0)
     rake (10.4.2)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    retriable (1.4.1)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
       rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.0)
+    rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.0)
+    rspec-expectations (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
-    rspec-mocks (3.2.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
-    rspec-puppet (1.0.1)
+    rspec-puppet (2.2.0)
       rspec
-    rspec-support (3.2.1)
-    rubocop (0.29.1)
+    rspec-support (3.2.2)
+    rsync (1.0.9)
+    rubocop (0.32.1)
       astrolabe (~> 1.3)
-      parser (>= 2.2.0.1, < 3.0)
+      parser (>= 2.2.2.5, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.7.1)
+    ruby-progressbar (1.7.5)
+    serverspec (2.20.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.38)
+    sfl (2.2)
+    signet (0.6.1)
+      addressable (~> 2.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
     slop (3.6.0)
+    specinfra (2.39.1)
+      net-scp
+      net-ssh (~> 2.7)
+      net-telnet
+      sfl
+    thread_safe (0.3.5)
+    trollop (2.1.2)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  beaker-rspec
   pry
   puppet (~> 3.7.0)
   puppetlabs_spec_helper

--- a/spec/acceptance/bonds_spec.rb
+++ b/spec/acceptance/bonds_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'interfaces' do
-
   context 'valid simple bond' do
-
     it 'should work with no errors' do
       pp = <<-EOS
         # Bond with defaults
@@ -14,26 +12,26 @@ describe 'interfaces' do
 
         # Bond, over-ride all defaults
         cumulus_bond { 'bond1':
-          slaves => ['swp5-6'],
-          ipv4 => ['10.0.0.1/24', '192.168.1.0/16'],
-          ipv6 => ['2001:db8:abcd::/48'],
-          alias_name => 'bond number 1',
-          #addr_method => 'static',
-          min_links => 2,
-          mode => 'balance-alb',
-          miimon => 99,
-          xmit_hash_policy => 'layer2',
-          lacp_rate => 1,
-          mtu => 9000,
+          slaves              => ['swp5-6'],
+          ipv4                => ['10.0.0.1/24', '192.168.1.0/16'],
+          ipv6                => ['2001:db8:abcd::/48'],
+          alias_name          => 'bond number 1',
+          #addr_method        => 'static',
+          min_links           => 2,
+          mode                => 'balance-alb',
+          miimon              => 99,
+          xmit_hash_policy    => 'layer2',
+          lacp_rate           => 1,
+          mtu                 => 9000,
           # ifquery doesn't seem to like clagd related parameters on an interface?
-          # clag_id => 1,
-          vids => ['1-4094'],
-          pvid => 1,
-          virtual_mac => '11:22:33:44:55:FF',
-          virtual_ip => '192.168.20.1',
+          # clag_id           => 1,
+          vids                => ['1-4094'],
+          pvid                => 1,
+          virtual_mac         => '11:22:33:44:55:FF',
+          virtual_ip          => '192.168.20.1',
           mstpctl_portnetwork => true,
-          mstpctl_bpduguard => true,
-          notify => Service['networking'],
+          mstpctl_bpduguard   => true,
+          notify              => Service['networking'],
         }
 
         file { '/etc/network/interfaces':
@@ -50,7 +48,7 @@ describe 'interfaces' do
         }
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, catch_failures: true)
     end
 
     intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
@@ -69,7 +67,7 @@ describe 'interfaces' do
 
     describe file("#{intf_dir}/bond1") do
       it { should be_file }
-      #its(:content) { should match(/iface bond1 inet static/) }
+      # its(:content) { should match(/iface bond1 inet static/) }
       its(:content) { should match(/iface bond1/) }
       its(:content) { should match(/bond-slaves glob swp5-6/) }
       its(:content) { should match(/mtu 9000/) }
@@ -81,12 +79,10 @@ describe 'interfaces' do
       its(:content) { should match(/alias bond number 1/) }
       its(:content) { should match(/bond-mode balance-alb/) }
       its(:content) { should match(/bond-xmit-hash-policy layer2/) }
-      its(:content) { should match(/address 10.0.0.1\/24 192.168.1.0\/16 2001:db8:abcd::\/48/) }
+      its(:content) { should match(%r{address 10.0.0.1/24 192.168.1.0/16 2001:db8:abcd::/48}) }
       its(:content) { should match(/address-virtual 11:22:33:44:55:FF 192.168.20.1/) }
       its(:content) { should match(/mstpctl-portnetwork yes/) }
       its(:content) { should match(/mstpctl-bpduguard yes/) }
     end
-
   end
-
 end

--- a/spec/acceptance/bonds_spec.rb
+++ b/spec/acceptance/bonds_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper_acceptance'
+
+describe 'interfaces' do
+
+  context 'valid simple bond' do
+
+    it 'should work with no errors' do
+      pp = <<-EOS
+        # Bond with defaults
+        cumulus_bond { 'bond0':
+          slaves => ['swp1-2', 'swp4'],
+          notify => Service['networking'],
+        }
+
+        # Bond, over-ride all defaults
+        cumulus_bond { 'bond1':
+          slaves => ['swp5-6'],
+          ipv4 => ['10.0.0.1/24', '192.168.1.0/16'],
+          ipv6 => ['2001:db8:abcd::/48'],
+          alias_name => 'bond number 1',
+          #addr_method => 'static',
+          min_links => 2,
+          mode => 'balance-alb',
+          miimon => 99,
+          xmit_hash_policy => 'layer2',
+          lacp_rate => 1,
+          mtu => 9000,
+          # ifquery doesn't seem to like clagd related parameters on an interface?
+          # clag_id => 1,
+          vids => ['1-4094'],
+          pvid => 1,
+          virtual_mac => '11:22:33:44:55:FF',
+          virtual_ip => '192.168.20.1',
+          mstpctl_portnetwork => true,
+          mstpctl_bpduguard => true,
+          notify => Service['networking'],
+        }
+
+        file { '/etc/network/interfaces':
+          content => "source /etc/network/interfaces.d/*\n"
+        }
+
+        service { 'networking':
+          ensure     => running,
+          hasrestart => true,
+          restart    => '/sbin/ifreload -a',
+          enable     => true,
+          hasstatus  => false,
+          require    => File['/etc/network/interfaces']
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
+
+    # The manifest should have created the .d directory
+    describe file(intf_dir) do
+      it { should be_directory }
+    end
+
+    # Should have been created by the cumulus_bond resource
+    describe file("#{intf_dir}/bond0") do
+      it { should be_file }
+      its(:content) { should match(/iface bond0/) }
+      its(:content) { should match(/bond-slaves glob swp1-2 swp4/) }
+    end
+
+    describe file("#{intf_dir}/bond1") do
+      it { should be_file }
+      #its(:content) { should match(/iface bond1 inet static/) }
+      its(:content) { should match(/iface bond1/) }
+      its(:content) { should match(/bond-slaves glob swp5-6/) }
+      its(:content) { should match(/mtu 9000/) }
+      its(:content) { should match(/bond-miimon 99/) }
+      its(:content) { should match(/bond-lacp-rate 1/) }
+      its(:content) { should match(/bond-min-links 2/) }
+      its(:content) { should match(/bridge-vids 1-4094/) }
+      its(:content) { should match(/bridge-pvid 1/) }
+      its(:content) { should match(/alias bond number 1/) }
+      its(:content) { should match(/bond-mode balance-alb/) }
+      its(:content) { should match(/bond-xmit-hash-policy layer2/) }
+      its(:content) { should match(/address 10.0.0.1\/24 192.168.1.0\/16 2001:db8:abcd::\/48/) }
+      its(:content) { should match(/address-virtual 11:22:33:44:55:FF 192.168.20.1/) }
+      its(:content) { should match(/mstpctl-portnetwork yes/) }
+      its(:content) { should match(/mstpctl-bpduguard yes/) }
+    end
+
+  end
+
+end

--- a/spec/acceptance/bridge_spec.rb
+++ b/spec/acceptance/bridge_spec.rb
@@ -1,29 +1,27 @@
 require 'spec_helper_acceptance'
 
 describe 'bridges' do
-
   context 'classic bridge driver' do
-
     it 'should work with no errors' do
       pp = <<-EOS
         # Classic bridge driver with defaults
         cumulus_bridge { 'br0':
-          ports => ['swp9', 'swp10-11', 'swp12'],
+          ports  => ['swp9', 'swp10-11', 'swp12'],
           notify => Service['networking'],
         }
 
         # Classic bridge driver over-ride all defaults
         cumulus_bridge { 'br1':
-          ports => ['swp13-14'],
-          ipv4 =>  ['10.0.0.1/24', '192.168.1.0/16'],
-          ipv6 => ['2001:db8:abcd::/48'],
-          alias_name => 'classic bridge number 1',
-          mtu => 9000,
-          stp => false,
+          ports            => ['swp13-14'],
+          ipv4             =>  ['10.0.0.1/24', '192.168.1.0/16'],
+          ipv6             => ['2001:db8:abcd::/48'],
+          alias_name       => 'classic bridge number 1',
+          mtu              => 9000,
+          stp              => false,
           mstpctl_treeprio => 4096,
-          virtual_ip => '192.168.100.1',
-          virtual_mac => '11:22:33:44:55:66',
-          notify => Service['networking'],
+          virtual_ip       => '192.168.100.1',
+          virtual_mac      => '11:22:33:44:55:66',
+          notify           => Service['networking'],
         }
 
         file { '/etc/network/interfaces':
@@ -40,7 +38,7 @@ describe 'bridges' do
         }
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, catch_failures: true)
     end
 
     intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
@@ -65,37 +63,35 @@ describe 'bridges' do
       its(:content) { should match(/bridge-stp no/) }
       its(:content) { should match(/mtu 9000/) }
       its(:content) { should match(/mstpctl-treeprio 4096/) }
-      its(:content) { should match(/address 10.0.0.1\/24 192.168.1.0\/16 2001:db8:abcd::\/48/) }
+      its(:content) { should match(%r{address 10.0.0.1/24 192.168.1.0/16 2001:db8:abcd::/48}) }
     end
-
   end
 
   context 'vlan aware bridge driver' do
-
     it 'should work with no errors' do
       pp = <<-EOS
         # New bridge driver with defaults
         cumulus_bridge { 'bridge2':
-          ports => ['swp15-16'],
+          ports      => ['swp15-16'],
           vlan_aware => true,
-          notify => Service['networking'],
+          notify     => Service['networking'],
         }
 
         # New bridge driver over-ride all defaults
         cumulus_bridge { 'bridge3':
-          ports => ['swp17-18'],
-          vlan_aware => true,
-          vids => ['1-4094'],
-          pvid => 1,
-          ipv4 => ['10.0.100.1/24', '192.168.100.0/16'],
-          ipv6 => ['2001:db8:1234::/48'],
-          alias_name => 'new bridge number 3',
-          mtu => 9000,
-          stp => false,
+          ports            => ['swp17-18'],
+          vlan_aware       => true,
+          vids             => ['1-4094'],
+          pvid             => 1,
+          ipv4             => ['10.0.100.1/24', '192.168.100.0/16'],
+          ipv6             => ['2001:db8:1234::/48'],
+          alias_name       => 'new bridge number 3',
+          mtu              => 9000,
+          stp              => false,
           mstpctl_treeprio => 4096,
-          virtual_ip => '192.168.100.2',
-          virtual_mac => 'aa:bb:cc:dd:ee:ff',
-          notify => Service['networking'],
+          virtual_ip       => '192.168.100.2',
+          virtual_mac      => 'aa:bb:cc:dd:ee:ff',
+          notify           => Service['networking'],
         }
 
         file { '/etc/network/interfaces':
@@ -112,7 +108,7 @@ describe 'bridges' do
         }
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, catch_failures: true)
     end
 
     intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
@@ -136,9 +132,7 @@ describe 'bridges' do
       its(:content) { should match(/mstpctl-treeprio 4096/) }
       its(:content) { should match(/bridge-pvid 1/) }
       its(:content) { should match(/bridge-vids 1-4094/) }
-      its(:content) { should match(/address 10.0.100.1\/24 192.168.100.0\/16 2001:db8:1234::\/48/) }
+      its(:content) { should match(%r{address 10.0.100.1/24 192.168.100.0/16 2001:db8:1234::/48}) }
     end
-
   end
- 
 end

--- a/spec/acceptance/bridge_spec.rb
+++ b/spec/acceptance/bridge_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper_acceptance'
+
+describe 'bridges' do
+
+  context 'classic bridge driver' do
+
+    it 'should work with no errors' do
+      pp = <<-EOS
+        # Classic bridge driver with defaults
+        cumulus_bridge { 'br0':
+          ports => ['swp9', 'swp10-11', 'swp12'],
+          notify => Service['networking'],
+        }
+
+        # Classic bridge driver over-ride all defaults
+        cumulus_bridge { 'br1':
+          ports => ['swp13-14'],
+          ipv4 =>  ['10.0.0.1/24', '192.168.1.0/16'],
+          ipv6 => ['2001:db8:abcd::/48'],
+          alias_name => 'classic bridge number 1',
+          mtu => 9000,
+          stp => false,
+          mstpctl_treeprio => 4096,
+          virtual_ip => '192.168.100.1',
+          virtual_mac => '11:22:33:44:55:66',
+          notify => Service['networking'],
+        }
+
+        file { '/etc/network/interfaces':
+          content => "source /etc/network/interfaces.d/*\n"
+        }
+
+        service { 'networking':
+          ensure     => running,
+          hasrestart => true,
+          restart    => '/sbin/ifreload -a',
+          enable     => true,
+          hasstatus  => false,
+          require    => File['/etc/network/interfaces']
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
+
+    # The manifest should have created the .d directory
+    describe file(intf_dir) do
+      it { should be_directory }
+    end
+
+    # classic bridge driver
+    describe file("#{intf_dir}/br0") do
+      it { should be_file }
+      its(:content) { should match(/iface br0/) }
+      its(:content) { should match(/bridge-ports swp9 glob swp10-11 swp12/) }
+      its(:content) { should match(/bridge-stp yes/) }
+    end
+
+    describe file("#{intf_dir}/br1") do
+      it { should be_file }
+      its(:content) { should match(/iface br1/) }
+      its(:content) { should match(/bridge-ports glob swp13-14/) }
+      its(:content) { should match(/bridge-stp no/) }
+      its(:content) { should match(/mtu 9000/) }
+      its(:content) { should match(/mstpctl-treeprio 4096/) }
+      its(:content) { should match(/address 10.0.0.1\/24 192.168.1.0\/16 2001:db8:abcd::\/48/) }
+    end
+
+  end
+
+  context 'vlan aware bridge driver' do
+
+    it 'should work with no errors' do
+      pp = <<-EOS
+        # New bridge driver with defaults
+        cumulus_bridge { 'bridge2':
+          ports => ['swp15-16'],
+          vlan_aware => true,
+          notify => Service['networking'],
+        }
+
+        # New bridge driver over-ride all defaults
+        cumulus_bridge { 'bridge3':
+          ports => ['swp17-18'],
+          vlan_aware => true,
+          vids => ['1-4094'],
+          pvid => 1,
+          ipv4 => ['10.0.100.1/24', '192.168.100.0/16'],
+          ipv6 => ['2001:db8:1234::/48'],
+          alias_name => 'new bridge number 3',
+          mtu => 9000,
+          stp => false,
+          mstpctl_treeprio => 4096,
+          virtual_ip => '192.168.100.2',
+          virtual_mac => 'aa:bb:cc:dd:ee:ff',
+          notify => Service['networking'],
+        }
+
+        file { '/etc/network/interfaces':
+          content => "source /etc/network/interfaces.d/*\n"
+        }
+
+        service { 'networking':
+          ensure     => running,
+          hasrestart => true,
+          restart    => '/sbin/ifreload -a',
+          enable     => true,
+          hasstatus  => false,
+          require    => File['/etc/network/interfaces']
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
+
+    # New bridge driver
+    describe file("#{intf_dir}/bridge2") do
+      it { should be_file }
+      its(:content) { should match(/iface bridge2/) }
+      its(:content) { should match(/bridge-vlan-aware yes/) }
+      its(:content) { should match(/bridge-ports glob swp15-16/) }
+      its(:content) { should match(/bridge-stp yes/) }
+    end
+
+    describe file("#{intf_dir}/bridge3") do
+      it { should be_file }
+      its(:content) { should match(/iface bridge3/) }
+      its(:content) { should match(/bridge-vlan-aware yes/) }
+      its(:content) { should match(/bridge-ports glob swp17-18/) }
+      its(:content) { should match(/bridge-stp no/) }
+      its(:content) { should match(/mtu 9000/) }
+      its(:content) { should match(/mstpctl-treeprio 4096/) }
+      its(:content) { should match(/bridge-pvid 1/) }
+      its(:content) { should match(/bridge-vids 1-4094/) }
+      its(:content) { should match(/address 10.0.100.1\/24 192.168.100.0\/16 2001:db8:1234::\/48/) }
+    end
+
+  end
+ 
+end

--- a/spec/acceptance/interface_spec.rb
+++ b/spec/acceptance/interface_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper_acceptance'
+
+describe 'interfaces' do
+
+  context 'valid simple interface' do
+
+    it 'should work with no errors' do
+      pp = <<-EOS
+        cumulus_interface { 'lo':
+          addr_method => 'loopback'
+        }
+
+        cumulus_interface { 'eth0':
+          addr_method => 'dhcp'
+        }
+
+        cumulus_interface { 'swp2':
+          ipv4 => ['10.30.1.1'],
+          notify => Service['networking'],
+        }
+
+        file { '/etc/network/interfaces':
+          content => "source /etc/network/interfaces.d/*\n"
+        }
+
+        service { 'networking':
+          ensure     => running,
+          hasrestart => true,
+          restart    => '/sbin/ifreload -a',
+          enable     => true,
+          hasstatus  => false,
+          require    => File['/etc/network/interfaces']
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      #expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+    end
+
+    describe interface('swp2') do
+      it { should exist }
+      it { should have_ipv4_address('10.30.1.1') }
+    end
+
+  end
+
+end

--- a/spec/acceptance/interface_spec.rb
+++ b/spec/acceptance/interface_spec.rb
@@ -34,7 +34,6 @@ describe 'interfaces' do
       EOS
 
       apply_manifest(pp, :catch_failures => true)
-      #expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
     end
 
     describe interface('swp2') do

--- a/spec/acceptance/interface_spec.rb
+++ b/spec/acceptance/interface_spec.rb
@@ -1,19 +1,17 @@
 require 'spec_helper_acceptance'
 
 describe 'interfaces' do
-
   context 'valid simple interface' do
-
     it 'should work with no errors' do
       pp = <<-EOS
         cumulus_interface { 'lo':
           addr_method => 'loopback',
-          notify => Service['networking'],
+          notify      => Service['networking'],
         }
 
         cumulus_interface { 'eth0':
           addr_method => 'dhcp',
-          notify => Service['networking'],
+          notify      => Service['networking'],
         }
 
         # With all defaults
@@ -23,24 +21,24 @@ describe 'interfaces' do
 
         # Over-ride defaults
         cumulus_interface { 'swp2':
-          ipv4 => ['192.168.200.1'],
-          ipv6 => ['2001:db8:5678::'],
-          #addr_method => 'static',
-          speed => '1000',
-          mtu => 9000,
+          ipv4                => ['192.168.200.1'],
+          ipv6                => ['2001:db8:5678::'],
+          #addr_method        => 'static',
+          speed               => '1000',
+          mtu                 => 9000,
           # ifquery doesn't seem to like clagd related parameters on an interface?
-          # clagd_enable true
-          # clagd_priority 1
-          # clagd_peer_ip '10.1.2.3'
-          # clagd_sys_mac 'aa:bb:cc:dd:ee:ff'
-          vids => ['1-4094'],
-          pvid => 1,
-          alias_name => 'interface swp2',
-          virtual_mac => '11:22:33:44:55:66',
-          virtual_ip => '192.168.10.1',
+          # clagd_enable      => true
+          # clagd_priority    => 1
+          # clagd_peer_ip     => '10.1.2.3'
+          # clagd_sys_mac     => 'aa:bb:cc:dd:ee:ff'
+          vids                => ['1-4094'],
+          pvid                => 1,
+          alias_name          => 'interface swp2',
+          virtual_mac         => '11:22:33:44:55:66',
+          virtual_ip          => '192.168.10.1',
           mstpctl_portnetwork => true,
-          mstpctl_bpduguard => true,
-          notify => Service['networking'],
+          mstpctl_bpduguard   => true,
+          notify              => Service['networking'],
         }
 
         file { '/etc/network/interfaces':
@@ -57,7 +55,7 @@ describe 'interfaces' do
         }
       EOS
 
-      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, catch_failures: true)
     end
 
     intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
@@ -82,7 +80,7 @@ describe 'interfaces' do
 
     describe file("#{intf_dir}/swp2") do
       it { should be_file }
-      #its(:content) { should match(/iface swp2 inet static/) }
+      # its(:content) { should match(/iface swp2 inet static/) }
       its(:content) { should match(/iface swp2/) }
       its(:content) { should match(/address 192.168.200.1 2001:db8:5678::/) }
       its(:content) { should match(/mtu 9000/) }
@@ -95,7 +93,5 @@ describe 'interfaces' do
       its(:content) { should match(/mstpctl-bpduguard yes/) }
       its(:content) { should match(/address-virtual/) }
     end
-
   end
-
 end

--- a/spec/acceptance/interface_spec.rb
+++ b/spec/acceptance/interface_spec.rb
@@ -7,15 +7,39 @@ describe 'interfaces' do
     it 'should work with no errors' do
       pp = <<-EOS
         cumulus_interface { 'lo':
-          addr_method => 'loopback'
+          addr_method => 'loopback',
+          notify => Service['networking'],
         }
 
         cumulus_interface { 'eth0':
-          addr_method => 'dhcp'
+          addr_method => 'dhcp',
+          notify => Service['networking'],
         }
 
+        # With all defaults
+        cumulus_interface { 'swp1':
+          notify => Service['networking'],
+        }
+
+        # Over-ride defaults
         cumulus_interface { 'swp2':
-          ipv4 => ['10.30.1.1'],
+          ipv4 => ['192.168.200.1'],
+          ipv6 => ['2001:db8:5678::'],
+          #addr_method => 'static',
+          speed => '1000',
+          mtu => 9000,
+          # ifquery doesn't seem to like clagd related parameters on an interface?
+          # clagd_enable true
+          # clagd_priority 1
+          # clagd_peer_ip '10.1.2.3'
+          # clagd_sys_mac 'aa:bb:cc:dd:ee:ff'
+          vids => ['1-4094'],
+          pvid => 1,
+          alias_name => 'interface swp2',
+          virtual_mac => '11:22:33:44:55:66',
+          virtual_ip => '192.168.10.1',
+          mstpctl_portnetwork => true,
+          mstpctl_bpduguard => true,
           notify => Service['networking'],
         }
 
@@ -36,9 +60,40 @@ describe 'interfaces' do
       apply_manifest(pp, :catch_failures => true)
     end
 
-    describe interface('swp2') do
-      it { should exist }
-      it { should have_ipv4_address('10.30.1.1') }
+    intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
+
+    # The manifest should have created the .d directory
+    describe file(intf_dir) do
+      it { should be_directory }
+    end
+
+    # Should exist
+    %w( eth0 lo ).each do |intf|
+      describe file("#{intf_dir}/#{intf}") do
+        it { should be_file }
+      end
+    end
+
+    # Should have been configured
+    describe file("#{intf_dir}/swp1") do
+      it { should be_file }
+      its(:content) { should match(/iface swp1/) }
+    end
+
+    describe file("#{intf_dir}/swp2") do
+      it { should be_file }
+      #its(:content) { should match(/iface swp2 inet static/) }
+      its(:content) { should match(/iface swp2/) }
+      its(:content) { should match(/address 192.168.200.1 2001:db8:5678::/) }
+      its(:content) { should match(/mtu 9000/) }
+      its(:content) { should match(/bridge-vids 1-4094/) }
+      its(:content) { should match(/bridge-pvid 1/) }
+      its(:content) { should match(/link-speed 1000/) }
+      its(:content) { should match(/link-duplex full/) }
+      its(:content) { should match(/alias interface swp2/) }
+      its(:content) { should match(/mstpctl-portnetwork yes/) }
+      its(:content) { should match(/mstpctl-bpduguard yes/) }
+      its(:content) { should match(/address-virtual/) }
     end
 
   end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,9 @@
+HOSTS:
+  cumulus-vx-2.5.3:
+    roles:
+      - master
+    platform: debian-253-amd64
+    box: cumulus-vx-2.5.3
+    hypervisor: vagrant
+CONFIG:
+  type: foss

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -14,9 +14,9 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module
-    puppet_module_install(:source => module_root, :module_name => 'cumulus_interfaces')
+    puppet_module_install(source: module_root, module_name: 'cumulus_interfaces')
     hosts.each do |host|
-      on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,22 @@
+require 'beaker-rspec'
+require 'pry'
+
+hosts.each do |host|
+  # Install Puppet
+  on host, 'apt-get update && apt-get install -y puppet'
+end
+
+RSpec.configure do |c|
+  module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module
+    puppet_module_install(:source => module_root, :module_name => 'cumulus_interfaces')
+    hosts.each do |host|
+      on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end


### PR DESCRIPTION
Use Beaker to provide acceptance tests. Most of the setup & tests are ported from the existing Chef tests.