### PR TITLE
Properly expand path of shared libraries

### DIFF
--- a/lib/puppet/provider/cumulus_interface/cumulus.rb
+++ b/lib/puppet/provider/cumulus_interface/cumulus.rb
@@ -1,4 +1,4 @@
-require 'cumulus/ifupdown2'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'cumulus', 'ifupdown2.rb'))
 Puppet::Type.type(:cumulus_interface).provide :cumulus do
   confine operatingsystem: [:cumuluslinux]
 

--- a/lib/puppet/type/cumulus_bridge.rb
+++ b/lib/puppet/type/cumulus_bridge.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter/boolean'
-require 'cumulus/utils'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'cumulus', 'utils.rb'))
 Puppet::Type.newtype(:cumulus_bridge) do
   desc 'Config cumulus bridge interface'
   include Cumulus::Utils

--- a/lib/puppet/type/cumulus_interface.rb
+++ b/lib/puppet/type/cumulus_interface.rb
@@ -1,4 +1,4 @@
-require 'cumulus/utils'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'cumulus', 'utils.rb'))
 require 'set'
 require 'puppet/parameter/boolean'
 Puppet::Type.newtype(:cumulus_interface) do


### PR DESCRIPTION
Properly expand path of shared libraries so that require statment works more reliably in different versions of Ruby and Puppet