### PR TITLE
Properly expand path of shared libraries

### DIFF
--- a/lib/puppet/provider/cumulus_bond/cumulus.rb
+++ b/lib/puppet/provider/cumulus_bond/cumulus.rb
@@ -1,4 +1,4 @@
-require 'cumulus/ifupdown2'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'cumulus', 'ifupdown2.rb'))
 Puppet::Type.type(:cumulus_bond).provide :cumulus do
   confine operatingsystem: [:cumuluslinux]
 

--- a/lib/puppet/type/cumulus_bond.rb
+++ b/lib/puppet/type/cumulus_bond.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter/boolean'
-require 'cumulus/utils'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'cumulus', 'utils.rb'))
 Puppet::Type.newtype(:cumulus_bond) do
   desc 'Configure bond interfaces on Cumulus Linux'
   include Cumulus::Utils


### PR DESCRIPTION
Properly expand path of shared libraries so that require statment works more reliably in different versions of Ruby and Puppet