### PR TITLE
CE-1130 Seperate IPv4 & IPv6 addresses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,6 @@ MethodLength:
   CountComments: false
   Max: 20
 ClassLength:
-  Max: 120
+  Enabled: false
 Metrics/LineLength:
   Enabled: false

--- a/lib/cumulus/ifupdown2.rb
+++ b/lib/cumulus/ifupdown2.rb
@@ -64,14 +64,18 @@ class Ifupdown2Config
   def build_address(addr_type)
     return nil.to_s if @resource[addr_type.to_sym].nil?
     Puppet.debug "updating #{addr_type} info #{@resource[:name]}"
-    @resource[addr_type.to_sym].join(' ')
+    @resource[addr_type.to_sym]
   end
 
   def update_address
-    addresslist = build_address('ipv4')
-    addresslist += ' ' + build_address('ipv6')
-    addresslist.strip!
+    ipv4_list = build_address('ipv4')
+    ipv6_list = build_address('ipv6')
+
+    addresslist = []
+    addresslist += ipv4_list unless ipv4_list.empty?
+    addresslist += ipv6_list unless ipv6_list.empty?
     return if addresslist.empty?
+
     @confighash['config']['address'] = addresslist
   end
 

--- a/spec/acceptance/bonds_spec.rb
+++ b/spec/acceptance/bonds_spec.rb
@@ -83,7 +83,9 @@ describe 'interfaces' do
       its(:content) { should match(/alias bond number 1/) }
       its(:content) { should match(/bond-mode balance-alb/) }
       its(:content) { should match(/bond-xmit-hash-policy layer2/) }
-      its(:content) { should match(%r{address 10.0.0.1/24 192.168.1.0/16 2001:db8:abcd::/48}) }
+      its(:content) { should match(%r{address 10.0.0.1/24}) }
+      its(:content) { should match(%r{address 192.168.1.0/16}) }
+      its(:content) { should match(%r{address 2001:db8:abcd::/48}) }
       its(:content) { should match(/address-virtual 11:22:33:44:55:FF 192.168.20.1/) }
       its(:content) { should match(/mstpctl-portnetwork yes/) }
       its(:content) { should match(/mstpctl-bpduguard yes/) }

--- a/spec/acceptance/bridge_spec.rb
+++ b/spec/acceptance/bridge_spec.rb
@@ -63,7 +63,9 @@ describe 'bridges' do
       its(:content) { should match(/bridge-stp no/) }
       its(:content) { should match(/mtu 9000/) }
       its(:content) { should match(/mstpctl-treeprio 4096/) }
-      its(:content) { should match(%r{address 10.0.0.1/24 192.168.1.0/16 2001:db8:abcd::/48}) }
+      its(:content) { should match(%r{address 10.0.0.1/24}) }
+      its(:content) { should match(%r{address 192.168.1.0/16}) }
+      its(:content) { should match(%r{address 2001:db8:abcd::/48}) }
     end
   end
 
@@ -132,7 +134,9 @@ describe 'bridges' do
       its(:content) { should match(/mstpctl-treeprio 4096/) }
       its(:content) { should match(/bridge-pvid 1/) }
       its(:content) { should match(/bridge-vids 1-4094/) }
-      its(:content) { should match(%r{address 10.0.100.1/24 192.168.100.0/16 2001:db8:1234::/48}) }
+      its(:content) { should match(%r{address 10.0.100.1/24}) }
+      its(:content) { should match(%r{address 192.168.100.0/16}) }
+      its(:content) { should match(%r{address 2001:db8:1234::/48}) }
     end
   end
 end

--- a/spec/acceptance/interface_spec.rb
+++ b/spec/acceptance/interface_spec.rb
@@ -83,7 +83,8 @@ describe 'interfaces' do
       it { should be_file }
       # its(:content) { should match(/iface swp2 inet static/) }
       its(:content) { should match(/iface swp2/) }
-      its(:content) { should match(/address 192.168.200.1 2001:db8:5678::/) }
+      its(:content) { should match(/address 192.168.200.1/) }
+      its(:content) { should match(/address 2001:db8:5678::/) }
       its(:content) { should match(/mtu 9000/) }
       its(:content) { should match(/bridge-vids 1-4094/) }
       its(:content) { should match(/bridge-pvid 1/) }

--- a/spec/unit/provider/cumulus_bond/base_spec.rb
+++ b/spec/unit/provider/cumulus_bond/base_spec.rb
@@ -87,7 +87,7 @@ describe provider_class do
     end
     context 'address options' do
       subject { confighash['config']['address'] }
-      it { is_expected.to eq '10.1.1.1/24 10:1:1::1/127' }
+      it { is_expected.to eq ['10.1.1.1/24', '10:1:1::1/127'] }
     end
     context 'interface description - alias' do
       subject { confighash['config']['alias'] }

--- a/spec/unit/provider/cumulus_bridge/base_spec.rb
+++ b/spec/unit/provider/cumulus_bridge/base_spec.rb
@@ -94,7 +94,7 @@ describe provider_class do
     end
     context 'address options' do
       subject { confighash['config']['address'] }
-      it { is_expected.to eq '10.1.1.1/24 10:1:1::1/127' }
+      it { is_expected.to eq ['10.1.1.1/24', '10:1:1::1/127'] }
     end
     context 'addr_method' do
       subject { confighash['addr_method'] }

--- a/spec/unit/provider/cumulus_interface/base_spec.rb
+++ b/spec/unit/provider/cumulus_interface/base_spec.rb
@@ -91,7 +91,7 @@ describe provider_class do
     end
     context 'address options' do
       subject { confighash['config']['address'] }
-      it { is_expected.to eq '10.1.1.1/24 10:1:1::1/127' }
+      it { is_expected.to eq ['10.1.1.1/24', '10:1:1::1/127'] }
     end
     context 'addr_method' do
       subject { confighash['addr_method'] }


### PR DESCRIPTION
Correctly separate IPv4 & IPv6 addresses so that ifquery can properly generate the address configurations.