### PR TITLE
Fix require path of ifupdown2 as in bond/interface

### DIFF
--- a/lib/puppet/provider/cumulus_bridge/cumulus.rb
+++ b/lib/puppet/provider/cumulus_bridge/cumulus.rb
@@ -1,4 +1,4 @@
-require 'cumulus/ifupdown2'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'cumulus', 'ifupdown2.rb'))
 Puppet::Type.type(:cumulus_bridge).provide :cumulus do
   confine operatingsystem: [:cumuluslinux]
 


### PR DESCRIPTION
The current require with the relative path does not work on an up2date puppet/cumulus 3.3