### PR TITLE
Fix absent interfaces bug; add default gateway configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Loopback interface and the management interface `eth0` using DHCP:
 
 ```ruby
 cumulus_interface { 'lo':
-  addr_method => 'loopback'
+  addr_method => 'loopback',
 }
 
 cumulus_interface { 'eth0':
-  addr_method  => 'dhcp'
+  addr_method => 'dhcp',
 }
 ```
 
@@ -70,8 +70,8 @@ cumulus_interface { 'eth0':
 
 ```ruby
 cumulus_interface { 'swp33':
-  ipv4 => ['10.30.1.1/24']
-  speed => 1000
+  ipv4  => ['10.30.1.1/24'],
+  speed => 1000,
 }
 ```
 
@@ -79,10 +79,10 @@ cumulus_interface { 'swp33':
 
 ```ruby
 cumulus_interface { 'peerlink.4094':
-  ipv4 => ['10.100.1.0/31']
-  clagd_enable => true
-  clagd_peer_ip => '10.100.1.1/31'
-  clagd_sys_mac => '44:38:39:ff:20:94'
+  ipv4          => ['10.100.1.0/31'],
+  clagd_enable  => true,
+  clagd_peer_ip => '10.100.1.1/31',
+  clagd_sys_mac => '44:38:39:ff:20:94',
 }
 ```
 
@@ -92,7 +92,7 @@ Bond named *peerlink* with the interfaces *swp1* and *swp2* as bond members:
 
 ```ruby
 cumulus_bond { 'peerlink':
-  slaves => ['swp1-2']
+  slaves => ['swp1-2'],
 }
 ```
 
@@ -100,9 +100,9 @@ Bond named *bond0* with the interfaces  *swp3* and  *swp4* as  bond members, the
 
 ```ruby
 cumulus_bond { 'bond0':
-  slaves => ['swp3-4'],
+  slaves    => ['swp3-4'],
   min_links => 2,
-  clag_id => 1
+  clag_id   => 1,
 }
 ```
 
@@ -112,12 +112,12 @@ cumulus_bond { 'bond0':
 
 ```ruby
 cumulus_bridge { 'br10':
-  ports      => ['swp11-12.1', 'swp32.1']
-  ipv4       => ['10.1.1.1/24', '10.20.1.1/24']
-  ipv6       => ['2001:db8:abcd::/48']
-  alias_name =>  'classic bridge'
-  mtu        => 9000
-  mstpctl_treeprio =>  4096
+  ports            => ['swp11-12.1', 'swp32.1'],
+  ipv4             => ['10.1.1.1/24', '10.20.1.1/24'],
+  ipv6             => ['2001:db8:abcd::/48'],
+  alias_name       => 'classic bridge',
+  mtu              => 9000,
+  mstpctl_treeprio => 4096,
 }
 ```
 
@@ -125,12 +125,12 @@ cumulus_bridge { 'br10':
 
 ```ruby
 cumulus_bridge { 'bridge':
-  vlan_aware => true
-  ports      => ['peerlink', 'downlink', 'swp10']
-  vids       => ['1-4094']
-  pvid       => 1
-  stp        => true
-  mstpctl_treeprio  => 4096
+  vlan_aware       => true,
+  ports            => ['peerlink', 'downlink', 'swp10'],
+  vids             => ['1-4094'],
+  pvid             => 1,
+  stp              => true,
+  mstpctl_treeprio => 4096,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ cumulus_interface { 'lo':
 cumulus_interface { 'eth0':
   addr_method => 'dhcp',
 }
+
+cumulus_interface { 'eth0':
+  ipv4    => ['192.168.0.10/24'],
+  gateway => '192.168.0.1',
+}
 ```
 
 *swp33* as a 1GbE port with a single IPv4 address:
@@ -145,6 +150,7 @@ cumulus_bridge { 'bridge':
 * `name` - Identifier for the interface.
 * `ipv4` - Array of IPv4 addresses to be applied to the interface.
 * `ipv6` - Array of IPv6 addresses to be applied to the interface.
+* `gateway` - String of default gateway to be added with the interface.
 * `alias_name` - Interface alias.
 * `addr_method` - Address assignment method, `dhcp` or `loopback`. Default is empty (no address method is set).
 * `speed` - The interface link speed.
@@ -180,6 +186,7 @@ The following CLAG-related attributes are also available. If CLAG is enabled, yo
 * ``lacp_rate`` - LACP bond rate. Default is 1 (fast LACP timeout).
 * ``ipv4`` - Array of IPv4 addresses to be applied to the interface.
 * ``ipv6`` - Array of IPv6 addresses to be applied to the interface.
+* ``gateway`` - String of default gateway to be added with the interface.
 * ``alias_name`` - Interface alias.
 * ``addr_method`` - Address assignment method. May be `dhcp` or empty. Default is empty (no address method is set).
 * ``mtu`` - The interface Maximum Transmission Unit (MTU).
@@ -205,6 +212,7 @@ The following CLAG-related attributes are also available. If CLAG is enabled, yo
 * `name` - Identifier for the bridge interface.
 * `ipv4` - Array of IPv4 addresses to be applied to the interface.
 * `ipv6` - Array of IPv6 addresses to be applied to the interface.
+* `gateway` - String of default gateway to be added with the interface.
 * `alias_name` - Interface alias.
 * `addr_method` - Address assignment method. May be `dhcp` or empty. Default is empty (no address method is set).
 * `mtu` - The interface Maximum Transmission Unit (MTU).

--- a/lib/cumulus/ifupdown2.rb
+++ b/lib/cumulus/ifupdown2.rb
@@ -22,12 +22,13 @@ class Ifupdown2Config
     filepath = @resource[:location] + '/' + @resource[:name]
     return {} unless File.exist?(filepath)
     json = ''
-    IO.popen("/sbin/ifquery #{@resource[:name]} -o json") do |ifquery|
+    IO.popen("/sbin/ifquery #{@resource[:name]} -o json", :err=>[:child, :out]) do |ifquery|
       json = ifquery.read
     end
     JSON.parse(json)[0]
   rescue StandardError => ex
-    Puppet.warning("ifquery failed: #{ex}")
+    Puppet.debug("ifquery failed: #{ex}")
+    {}
   end
 
   # before 2.5.4 null entries where left in place in hash

--- a/lib/puppet/provider/cumulus_bond/cumulus.rb
+++ b/lib/puppet/provider/cumulus_bond/cumulus.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:cumulus_bond).provide :cumulus do
     config.update_alias_name
     config.update_vrr
     # attributes with no suffix like bond-, or bridge-
-    %w(mstpctl_portnetwork mstpctl_bpduguard mstpctl_portadminedge clag_id mtu).each do |attr|
+    %w(mstpctl_portnetwork mstpctl_bpduguard mstpctl_portadminedge clag_id mtu gateway).each do |attr|
       config.update_attr(attr)
     end
     # copy to instance variable

--- a/lib/puppet/provider/cumulus_bridge/cumulus.rb
+++ b/lib/puppet/provider/cumulus_bridge/cumulus.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:cumulus_bridge).provide :cumulus do
     config.update_alias_name
     config.update_vrr
     # attributes with no suffix like bond-, or bridge-
-    %w(mstpctl_treeprio mtu).each do |attr|
+    %w(mstpctl_treeprio mtu gateway).each do |attr|
       config.update_attr(attr)
     end
     # copy to instance variable

--- a/lib/puppet/provider/cumulus_interface/cumulus.rb
+++ b/lib/puppet/provider/cumulus_interface/cumulus.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:cumulus_interface).provide :cumulus do
     config.update_vrr
     # attributes with no suffix like bond-, or bridge-
     %w(mstpctl_portnetwork mstpctl_bpduguard mstpctl_portadminedge clagd_enable clagd_priority
-       clagd_backup_ip clagd_args clagd_sys_mac clagd_peer_ip mtu).each do |attr|
+       clagd_backup_ip clagd_args clagd_sys_mac clagd_peer_ip mtu gateway).each do |attr|
       config.update_attr(attr)
     end
     # copy to instance variable

--- a/lib/puppet/type/cumulus_bond.rb
+++ b/lib/puppet/type/cumulus_bond.rb
@@ -193,6 +193,10 @@ Puppet::Type.newtype(:cumulus_bond) do
     end
   end
 
+  newparam(:gateway) do
+    desc 'default gateway'
+  end
+
   validate do
     if self[:slaves].nil?
       fail Puppet::Error, 'bond members/slaves must be configured'

--- a/lib/puppet/type/cumulus_bridge.rb
+++ b/lib/puppet/type/cumulus_bridge.rb
@@ -129,6 +129,10 @@ Puppet::Type.newtype(:cumulus_bridge) do
     end
   end
 
+  newparam(:gateway) do
+    desc 'default gateway'
+  end
+
   validate do
     fail Puppet::Error, 'ports list required' if self[:ports].nil?
 

--- a/lib/puppet/type/cumulus_interface.rb
+++ b/lib/puppet/type/cumulus_interface.rb
@@ -154,6 +154,10 @@ Puppet::Type.newtype(:cumulus_interface) do
     clagd parameters. It is optional'
   end
 
+  newparam(:gateway) do
+    desc 'default gateway'
+  end
+
   validate do
     myset = [self[:clagd_enable].nil?, self[:clagd_peer_ip].nil?,
              self[:clagd_sys_mac].nil?].to_set


### PR DESCRIPTION
Hi,

while I was integrating this module in our puppet codebase, I've encountered some troubles:
1. Absent interfaces were unable to configure.
Code like this:
```
# cat test.pp 
cumulus_bond { 'peerlink':
  slaves => ['swp1', 'swp2'],
}
```
Caused such errors:
```
# puppet apply test.pp 
Notice: Compiled catalog for cumulus-1.local in environment production in 0.10 seconds 
error: cannot find interfaces: peerlink 
Warning: ifquery failed: A JSON text must at least contain two octets! 
Error: /Stage[main]/Main/Cumulus_bond[peerlink]: Could not evaluate: undefined method `delete_if' for #<Puppet::Util::Log:0x00000004a23150> 
Notice: Applied catalog in 0.19 seconds 
```

This was caused by `ifquery` command, which returned error of absent interface `peerlink`. For instance:
```
root@cumulus-1:~# ifquery absent_interface -o json
error: cannot find interfaces: absent_interface
```

2. Added default gateway configuration. When I want to setup static IP on eth0, I also want to add default gateway for it.
3. I've done some formatting in readme regarding puppet style guide. 


These changes were tested with cumulus linux 3.3.1 (on Cumulus VX and Mellanox SN2100).

Signed-off-by: Vladislav Odintsov <odivlad@gmail.com>