### PR TITLE
Compatibility with Ruby 1.8

### DIFF
--- a/lib/cumulus/ifupdown2.rb
+++ b/lib/cumulus/ifupdown2.rb
@@ -49,7 +49,7 @@ class Ifupdown2Config
   def hash_to_if
     intf = ''
     cmd = "/sbin/ifquery -i - -t json #{@resource[:name]}"
-    IO.popen(cmd, mode: 'r+') do |ifquery|
+    IO.popen(cmd, :mode => 'r+') do |ifquery|
       ifquery.write([@confighash].to_json)
       ifquery.close_write
       intf = ifquery.read

--- a/lib/puppet/provider/cumulus_bond/cumulus.rb
+++ b/lib/puppet/provider/cumulus_bond/cumulus.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'cumulus', 'ifupdown2.rb'))
 Puppet::Type.type(:cumulus_bond).provide :cumulus do
-  confine operatingsystem: [:cumuluslinux]
+  confine :operatingsystem => [:cumuluslinux]
 
   def build_desired_config
     config = Ifupdown2Config.new(resource)

--- a/lib/puppet/provider/cumulus_bridge/cumulus.rb
+++ b/lib/puppet/provider/cumulus_bridge/cumulus.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'cumulus', 'ifupdown2.rb'))
 Puppet::Type.type(:cumulus_bridge).provide :cumulus do
-  confine operatingsystem: [:cumuluslinux]
+  confine :operatingsystem => [:cumuluslinux]
 
   def build_desired_config
     config = Ifupdown2Config.new(resource)

--- a/lib/puppet/provider/cumulus_interface/cumulus.rb
+++ b/lib/puppet/provider/cumulus_interface/cumulus.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'cumulus', 'ifupdown2.rb'))
 Puppet::Type.type(:cumulus_interface).provide :cumulus do
-  confine operatingsystem: [:cumuluslinux]
+  confine :operatingsystem => [:cumuluslinux]
 
   def build_desired_config
     config = Ifupdown2Config.new(resource)

--- a/lib/puppet/type/cumulus_bond.rb
+++ b/lib/puppet/type/cumulus_bond.rb
@@ -86,22 +86,22 @@ Puppet::Type.newtype(:cumulus_bond) do
   end
 
   newparam(:mstpctl_portnetwork,
-           boolean: true,
-           parent: Puppet::Parameter::Boolean) do
+           :boolean => true,
+           :parent => Puppet::Parameter::Boolean) do
     desc 'configures bridge assurance. Ensure that port is in vlan
     aware mode'
   end
 
   newparam(:mstpctl_bpduguard,
-           boolean: true,
-           parent: Puppet::Parameter::Boolean) do
+           :boolean => true,
+           :parent => Puppet::Parameter::Boolean) do
     desc 'configures bpdu guard. Ensure that the port is in vlan
     aware mode'
   end
 
   newparam(:mstpctl_portadminedge,
-           boolean: false,
-           parent: Puppet::Parameter::Boolean) do
+           :boolean => false,
+           :parent => Puppet::Parameter::Boolean) do
     desc 'configures port adminedge.'
   end
 

--- a/lib/puppet/type/cumulus_bridge.rb
+++ b/lib/puppet/type/cumulus_bridge.rb
@@ -101,15 +101,15 @@ Puppet::Type.newtype(:cumulus_bridge) do
   end
 
   newparam(:stp,
-           boolean: true,
-           parent: Puppet::Parameter::Boolean) do
+           :boolean => true,
+           :parent => Puppet::Parameter::Boolean) do
     desc 'enables spanning tree. default is "on" '
     defaultto true
   end
 
   newparam(:vlan_aware,
-           boolean: true,
-           parent:  Puppet::Parameter::Boolean) do
+           :boolean => true,
+           :parent =>  Puppet::Parameter::Boolean) do
     desc 'enables vlan aware mode. Selects between the
     classic bridge driver and vlan aware bridge driver.
     Only one bridge should be covered in vlan aware mode'

--- a/lib/puppet/type/cumulus_interface.rb
+++ b/lib/puppet/type/cumulus_interface.rb
@@ -98,28 +98,28 @@ Puppet::Type.newtype(:cumulus_interface) do
   end
 
   newparam(:mstpctl_portnetwork,
-           boolean: true,
-           parent: Puppet::Parameter::Boolean) do
+           :boolean => true,
+           :parent => Puppet::Parameter::Boolean) do
     desc 'configures bridge assurance. Ensure that port is in vlan
     aware mode'
   end
 
   newparam(:mstpctl_bpduguard,
-           boolean: true,
-           parent: Puppet::Parameter::Boolean) do
+           :boolean => true,
+           :parent => Puppet::Parameter::Boolean) do
     desc 'configures bpdu guard. Ensure that the port is in vlan
     aware mode'
   end
 
   newparam(:mstpctl_portadminedge,
-           boolean: false,
-           parent: Puppet::Parameter::Boolean) do
+           :boolean => false,
+           :parent => Puppet::Parameter::Boolean) do
     desc 'configures port adminedge.'
   end
 
   newparam(:clagd_enable,
-           boolean: true,
-           parent: Puppet::Parameter::Boolean) do
+           :boolean => true,
+           :parent => Puppet::Parameter::Boolean) do
     desc 'enable CLAG on the interface. Interface must be in vlan \
     aware mode. clagd_enable, clagd_peer_ip, clagd_backup_ip,
     clagd_sys_mac must be configured together'

--- a/spec/acceptance/bonds_spec.rb
+++ b/spec/acceptance/bonds_spec.rb
@@ -52,7 +52,7 @@ describe 'interfaces' do
         }
       EOS
 
-      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, :catch_failures => true)
     end
 
     intf_dir = File.join('', 'etc', 'network', 'interfaces.d')

--- a/spec/acceptance/bridge_spec.rb
+++ b/spec/acceptance/bridge_spec.rb
@@ -38,7 +38,7 @@ describe 'bridges' do
         }
       EOS
 
-      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, :catch_failures => true)
     end
 
     intf_dir = File.join('', 'etc', 'network', 'interfaces.d')
@@ -110,7 +110,7 @@ describe 'bridges' do
         }
       EOS
 
-      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, :catch_failures => true)
     end
 
     intf_dir = File.join('', 'etc', 'network', 'interfaces.d')

--- a/spec/acceptance/interface_spec.rb
+++ b/spec/acceptance/interface_spec.rb
@@ -56,7 +56,7 @@ describe 'interfaces' do
         }
       EOS
 
-      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, :catch_failures => true)
     end
 
     intf_dir = File.join('', 'etc', 'network', 'interfaces.d')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -21,9 +21,9 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module
-    puppet_module_install(source: module_root, module_name: 'cumulus_interfaces')
+    puppet_module_install(:source => module_root, :module_name => 'cumulus_interfaces')
     hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppetlabs-stdlib'), :acceptable_exit_codes => [0, 1]
     end
   end
 end

--- a/spec/unit/provider/cumulus_bond/base_spec.rb
+++ b/spec/unit/provider/cumulus_bond/base_spec.rb
@@ -10,20 +10,20 @@ describe provider_class do
     # this is not a valid entry to use in a real scenario..
     # only designed for testing
     @resource = provider_resource.new(
-      name: 'bond0',
-      vids: ['1-10', '20'],
-      ipv4: '10.1.1.1/24',
-      ipv6: ['10:1:1::1/127'],
-      alias_name: 'my int description',
-      virtual_ip: '10.1.1.1/24',
-      virtual_mac: '00:00:5e:00:00:01',
-      mstpctl_bpduguard: true,
-      mstpctl_portnetwork: false,
-      mtu: 9000,
-      lacp_bypass_allow: 1,
-      lacp_bypass_period: 30,
-      lacp_bypass_all_active: 1,
-      slaves: ['bond0-3']
+      :name => 'bond0',
+      :vids => ['1-10', '20'],
+      :ipv4 => '10.1.1.1/24',
+      :ipv6 => ['10:1:1::1/127'],
+      :alias_name => 'my int description',
+      :virtual_ip => '10.1.1.1/24',
+      :virtual_mac => '00:00:5e:00:00:01',
+      :mstpctl_bpduguard => true,
+      :mstpctl_portnetwork => false,
+      :mtu => 9000,
+      :lacp_bypass_allow => 1,
+      :lacp_bypass_period => 30,
+      :lacp_bypass_all_active => 1,
+      :slaves => ['bond0-3']
     )
     @provider = provider_class.new(@resource)
   end
@@ -38,9 +38,9 @@ describe provider_class do
   context 'config changed' do
     before do
       @loc_resource = provider_resource.new(
-        name: 'bond0',
-        slaves: 'bond0-2',
-        vids: ['1-10', '20'])
+        :name => 'bond0',
+        :slaves => 'bond0-2',
+        :vids => ['1-10', '20'])
     end
     context 'config has changed' do
       before do

--- a/spec/unit/provider/cumulus_bridge/base_spec.rb
+++ b/spec/unit/provider/cumulus_bridge/base_spec.rb
@@ -11,19 +11,19 @@ describe provider_class do
     # this is not a valid entry to use in a real scenario..
     # only designed for testing
     @resource = provider_resource.new(
-      name: 'swp1',
-      vids: ['1-10', '20'],
-      speed: 1000,
-      ipv4: '10.1.1.1/24',
-      ipv6: ['10:1:1::1/127'],
-      addr_method: 'dhcp',
-      alias_name: 'my int description',
-      virtual_ip: '10.1.1.1/24',
-      virtual_mac: '00:00:5e:00:00:01',
-      mstpctl_treeprio: 4096,
-      mtu: 9000,
-      mcsnoop: 1,
-      ports: ['swp1-3', 'bond0']
+      :name => 'swp1',
+      :vids => ['1-10', '20'],
+      :speed => 1000,
+      :ipv4 => '10.1.1.1/24',
+      :ipv6 => ['10:1:1::1/127'],
+      :addr_method => 'dhcp',
+      :alias_name => 'my int description',
+      :virtual_ip => '10.1.1.1/24',
+      :virtual_mac => '00:00:5e:00:00:01',
+      :mstpctl_treeprio => 4096,
+      :mtu => 9000,
+      :mcsnoop => 1,
+      :ports => ['swp1-3', 'bond0']
     )
     @provider = provider_class.new(@resource)
   end
@@ -38,8 +38,8 @@ describe provider_class do
   context 'config changed' do
     before do
       @loc_resource = provider_resource.new(
-        name: 'br0',
-        ports: ['swp1-3'])
+        :name => 'br0',
+        :ports => ['swp1-3'])
     end
     context 'config has changed' do
       before do

--- a/spec/unit/provider/cumulus_interface/base_spec.rb
+++ b/spec/unit/provider/cumulus_interface/base_spec.rb
@@ -10,22 +10,22 @@ describe provider_class do
     # this is not a valid entry to use in a real scenario..
     # only designed for testing
     @resource = provider_resource.new(
-      name: 'swp1',
-      vids: ['1-10', '20'],
-      speed: 1000,
-      ipv4: '10.1.1.1/24',
-      ipv6: ['10:1:1::1/127'],
-      addr_method: 'loopback',
-      alias_name: 'my int description',
-      virtual_ip: '10.1.1.1/24',
-      virtual_mac: '00:00:5e:00:00:01',
-      mstpctl_bpduguard: true,
-      mstpctl_portnetwork: false,
-      mtu: 9000,
-      clagd_enable: true,
-      clagd_sys_mac: '44:38:39:ff:20:94',
-      clagd_peer_ip: '10.1.1.1',
-      clagd_backup_ip: '10.1.2.1'
+      :name => 'swp1',
+      :vids => ['1-10', '20'],
+      :speed => 1000,
+      :ipv4 => '10.1.1.1/24',
+      :ipv6 => ['10:1:1::1/127'],
+      :addr_method => 'loopback',
+      :alias_name => 'my int description',
+      :virtual_ip => '10.1.1.1/24',
+      :virtual_mac => '00:00:5e:00:00:01',
+      :mstpctl_bpduguard => true,
+      :mstpctl_portnetwork => false,
+      :mtu => 9000,
+      :clagd_enable => true,
+      :clagd_sys_mac => '44:38:39:ff:20:94',
+      :clagd_peer_ip => '10.1.1.1',
+      :clagd_backup_ip => '10.1.2.1'
 
     )
     @provider = provider_class.new(@resource)
@@ -60,14 +60,14 @@ describe provider_class do
   context 'config changed' do
     before do
       @loc_resource = provider_resource.new(
-        name: 'swp1',
-        vids: ['1-10', '20'])
+        :name => 'swp1',
+        :vids => ['1-10', '20'])
     end
     context 'has not changed witih single ip address post 2.5.4' do
       before do
         @loc_resource = provider_resource.new(
-          name: 'swp1',
-          ipv4: '10.1.1.1/24'
+          :name => 'swp1',
+          :ipv4 => '10.1.1.1/24'
         )
         # needed to ensure that if_to_hash() exists to get @config.currenthash
         allow(File).to receive(:exist?).and_return(true)
@@ -86,8 +86,8 @@ describe provider_class do
     context 'has not changed with single ip address pre 2.5.4' do
       before do
         @loc_resource = provider_resource.new(
-          name: 'swp1',
-          ipv4: '10.1.1.1/24'
+          :name => 'swp1',
+          :ipv4 => '10.1.1.1/24'
         )
         # needed to ensure that if_to_hash() exists to get @config.currenthash
         allow(File).to receive(:exist?).and_return(true)

--- a/spec/unit/type/cumulus_bond_spec.rb
+++ b/spec/unit/type/cumulus_bond_spec.rb
@@ -42,8 +42,8 @@ describe cl_iface do
 
   context 'defaults for' do
     before do
-      @bondtype = cl_iface.new(name: 'bond0',
-                               slaves: ['swp1-2'])
+      @bondtype = cl_iface.new(:name => 'bond0',
+                               :slaves => ['swp1-2'])
     end
     { 'lacp_rate' => 1,
       'min_links' => 1,
@@ -61,18 +61,18 @@ describe cl_iface do
       context 'if not all vrr parameters are set' do
         it do
           expect do
-            cl_iface.new(name: 'bond0',
-                         slaves: 'swp1-2',
-                         virtual_ip: '10.1.1.1/24')
+            cl_iface.new(:name => 'bond0',
+                         :slaves => 'swp1-2',
+                         :virtual_ip => '10.1.1.1/24')
           end.to raise_error
         end
         context 'if all vrr parameters are set' do
           it do
             expect do
-              cl_iface.new(name: 'bond0',
-                           slaves: 'swp1-2',
-                           virtual_ip: '10.1.1.1/24',
-                           virtual_mac: '00:00:5e:00:00:01')
+              cl_iface.new(:name => 'bond0',
+                           :slaves => 'swp1-2',
+                           :virtual_ip => '10.1.1.1/24',
+                           :virtual_mac => '00:00:5e:00:00:01')
             end.to_not raise_error
           end
         end

--- a/spec/unit/type/cumulus_bridge_spec.rb
+++ b/spec/unit/type/cumulus_bridge_spec.rb
@@ -42,10 +42,10 @@ describe cl_iface do
 
   context 'defaults for' do
     before do
-      @bondtype = cl_iface.new(name: 'br0',
-                               ports: ['bond0-2'])
+      @bondtype = cl_iface.new(:name => 'br0',
+                               :ports => ['bond0-2'])
     end
-    { stp: true }.each do |k, v|
+    { :stp => true }.each do |k, v|
       context k do
         it { expect(@bondtype.value(k)).to eq v }
       end
@@ -56,20 +56,20 @@ describe cl_iface do
     context 'ports parameter' do
       context 'if not set' do
         it do
-          expect { cl_iface.new(name: 'br0') }.to raise_error
+          expect { cl_iface.new(:name => 'br0') }.to raise_error
         end
       end
       context 'if set' do
         it do
           expect do
-            cl_iface.new(name: 'br0',
-                         ports: ['swp1-12'])
+            cl_iface.new(:name => 'br0',
+                         :ports => ['swp1-12'])
           end.to_not raise_error
         end
         it 'should be an array' do
           expect do
-            cl_iface.new(name: 'br0',
-                         ports: 'swp1-12, swp13')
+            cl_iface.new(:name => 'br0',
+                         :ports => 'swp1-12, swp13')
           end.to raise_error
         end
       end
@@ -79,18 +79,18 @@ describe cl_iface do
       context 'if not all vrr parameters are set' do
         it do
           expect do
-            cl_iface.new(name: 'swp1',
-                         ports: ['swp1-2'],
-                         virtual_ip: '10.1.1.1/24')
+            cl_iface.new(:name => 'swp1',
+                         :ports => ['swp1-2'],
+                         :virtual_ip => '10.1.1.1/24')
           end.to raise_error
         end
         context 'if all vrr parameters are set' do
           it do
             expect do
-              cl_iface.new(name: 'swp1',
-                           virtual_ip: '10.1.1.1/24',
-                           ports: ['swp1-2'],
-                           virtual_mac: '00:00:5e:00:00:01')
+              cl_iface.new(:name => 'swp1',
+                           :virtual_ip => '10.1.1.1/24',
+                           :ports => ['swp1-2'],
+                           :virtual_mac => '00:00:5e:00:00:01')
             end.to_not raise_error
           end
         end

--- a/spec/unit/type/cumulus_interface_spec.rb
+++ b/spec/unit/type/cumulus_interface_spec.rb
@@ -45,8 +45,8 @@ describe cl_iface do
   context 'validation' do
     context 'ip address' do
       before do
-        @resource1 = cl_iface.new(name: 'swp1',
-                                  ipv4: '10.1.1.1/24')
+        @resource1 = cl_iface.new(:name => 'swp1',
+                                  :ipv4 => '10.1.1.1/24')
       end
       subject { @resource1.value(:ipv4) }
       it { is_expected.to eq ['10.1.1.1/24'] }
@@ -56,16 +56,16 @@ describe cl_iface do
       context 'if not all vrr parameters are set' do
         it do
           expect do
-            cl_iface.new(name: 'swp1',
-                         virtual_ip: '10.1.1.1/24')
+            cl_iface.new(:name => 'swp1',
+                         :virtual_ip => '10.1.1.1/24')
           end.to raise_error
         end
         context 'if all vrr parameters are set' do
           it do
             expect do
-              cl_iface.new(name: 'swp1',
-                           virtual_ip: '10.1.1.1/24',
-                           virtual_mac: '00:00:5e:00:00:01')
+              cl_iface.new(:name => 'swp1',
+                           :virtual_ip => '10.1.1.1/24',
+                           :virtual_mac => '00:00:5e:00:00:01')
             end.to_not raise_error
           end
         end
@@ -74,22 +74,22 @@ describe cl_iface do
           context 'if not all clag parameters are set' do
             it do
               expect do
-                cl_iface.new(name: 'swp1',
-                             clagd_enable: 'yes')
+                cl_iface.new(:name => 'swp1',
+                             :clagd_enable => 'yes')
               end.to raise_error
             end
           end
           context 'if not configured' do
-            it { expect { cl_iface.new(name: 'swp1') }.to_not raise_error }
+            it { expect { cl_iface.new(:name => 'swp1') }.to_not raise_error }
           end
           context 'if all are configured' do
             it do
               expect do
-                cl_iface.new(name: 'swp1',
-                             clagd_enable: true,
-                             clagd_priority: 2000,
-                             clagd_sys_mac: '44:38:38:ff:00:11',
-                             clagd_peer_ip: '10.1.1.1')
+                cl_iface.new(:name => 'swp1',
+                             :clagd_enable => true,
+                             :clagd_priority => 2000,
+                             :clagd_sys_mac => '44:38:38:ff:00:11',
+                             :clagd_peer_ip => '10.1.1.1')
               end.to_not raise_error
             end
           end
@@ -98,20 +98,20 @@ describe cl_iface do
               context ' is not set' do
                 it do
                   expect do
-                    cl_iface.new(name: 'swp1',
-                                 clagd_backup_ip: '1.1.1.1')
+                    cl_iface.new(:name => 'swp1',
+                                 :clagd_backup_ip => '1.1.1.1')
                   end.to raise_error
                 end
               end
               context 'is set' do
                 it do
                   expect do
-                    cl_iface.new(name: 'swp1',
-                                 clagd_enable: true,
-                                 clagd_priority: 2000,
-                                 clagd_sys_mac: '44:38:38:ff:00:11',
-                                 clagd_peer_ip: '10.1.1.1',
-                                 clagd_backup_ip: '10.1.2.1')
+                    cl_iface.new(:name => 'swp1',
+                                 :clagd_enable => true,
+                                 :clagd_priority => 2000,
+                                 :clagd_sys_mac => '44:38:38:ff:00:11',
+                                 :clagd_peer_ip => '10.1.1.1',
+                                 :clagd_backup_ip => '10.1.2.1')
                   end.to_not raise_error
                 end
               end
@@ -123,20 +123,20 @@ describe cl_iface do
               context ' is not set' do
                 it do
                   expect do
-                    cl_iface.new(name: 'swp1',
-                                 clagd_args: '--vm')
+                    cl_iface.new(:name => 'swp1',
+                                 :clagd_args => '--vm')
                   end.to raise_error
                 end
               end
               context 'is set' do
                 it do
                   expect do
-                    cl_iface.new(name: 'swp1',
-                                 clagd_enable: true,
-                                 clagd_priority: 2000,
-                                 clagd_sys_mac: '44:38:38:ff:00:11',
-                                 clagd_peer_ip: '10.1.1.1',
-                                 clagd_args: '--vm')
+                    cl_iface.new(:name => 'swp1',
+                                 :clagd_enable => true,
+                                 :clagd_priority => 2000,
+                                 :clagd_sys_mac => '44:38:38:ff:00:11',
+                                 :clagd_peer_ip => '10.1.1.1',
+                                 :clagd_args => '--vm')
                   end.to_not raise_error
                 end
               end


### PR DESCRIPTION
When Puppet master is running on an old installation running Ruby 1.8 (Ubuntu Precise, CentOS 6), this module doesn't work because of the new-style hash (introduced in Ruby 1.9). This PR reverts to old-style hash to brings back Ruby 1.8 compatibility.

Most Puppet modules seem to stick to Ruby 1.8 compatibility (first time I got this problem). However, feel free to just close the PR if you are not interested. People needing it will likely find it.