### PR TITLE
Make auto negotiation configurable via puppet resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ cumulus_bridge { 'bridge':
 * `alias_name` - Interface alias.
 * `addr_method` - Address assignment method, `dhcp` or `loopback`. Default is empty (no address method is set).
 * `speed` - The interface link speed.
+* `autoneg` - Link Auto-Negotiation (on/off)
 * `mtu` - The interface Maximum Transmission Unit (MTU).
 * `virtual_ip` - VRR virtual IP address.
 * `virtual_mac` - VRR virtual MAC address.

--- a/lib/cumulus/ifupdown2.rb
+++ b/lib/cumulus/ifupdown2.rb
@@ -123,6 +123,12 @@ class Ifupdown2Config
     @confighash['config']['link-duplex'] = 'full'
   end
 
+  def update_autoneg
+    return if @resource[:autoneg].nil?
+    Puppet.debug "configuring auto negotiation #{@resource[:name]}"
+    @confighash['config']['link-autoneg'] = @resource[:autoneg]
+  end
+
   # updates vrr config in config hash
   def update_vrr
     return if @resource[:virtual_ip].nil?

--- a/lib/puppet/provider/cumulus_interface/cumulus.rb
+++ b/lib/puppet/provider/cumulus_interface/cumulus.rb
@@ -4,6 +4,7 @@ Puppet::Type.type(:cumulus_interface).provide :cumulus do
 
   def build_desired_config
     config = Ifupdown2Config.new(resource)
+    config.update_autoneg
     config.update_speed
     config.update_addr_method
     config.update_address

--- a/lib/puppet/type/cumulus_interface.rb
+++ b/lib/puppet/type/cumulus_interface.rb
@@ -63,6 +63,10 @@ Puppet::Type.newtype(:cumulus_interface) do
     end
   end
 
+  newparam(:autoneg) do
+    desc 'explicitly en/disable auto negotiation (on/off)'
+  end
+
   newparam(:mtu) do
     desc 'link mtu. Can be 1500 to 9000 KBs'
     munge do |value|

--- a/spec/acceptance/interface_spec.rb
+++ b/spec/acceptance/interface_spec.rb
@@ -25,6 +25,7 @@ describe 'interfaces' do
           ipv6                  => ['2001:db8:5678::'],
           #addr_method          => 'static',
           speed                 => '1000',
+          autoneg               => 'on',
           mtu                   => 9000,
           # ifquery doesn't seem to like clagd related parameters on an interface?
           # clagd_enable        => true
@@ -89,6 +90,7 @@ describe 'interfaces' do
       its(:content) { should match(/bridge-vids 1-4094/) }
       its(:content) { should match(/bridge-pvid 1/) }
       its(:content) { should match(/link-speed 1000/) }
+      its(:content) { should match(/link-autoneg on/) }
       its(:content) { should match(/link-duplex full/) }
       its(:content) { should match(/alias interface swp2/) }
       its(:content) { should match(/mstpctl-portnetwork yes/) }

--- a/spec/unit/provider/cumulus_interface/base_spec.rb
+++ b/spec/unit/provider/cumulus_interface/base_spec.rb
@@ -13,6 +13,7 @@ describe provider_class do
       name: 'swp1',
       vids: ['1-10', '20'],
       speed: 1000,
+      autoneg: 'on',
       ipv4: '10.1.1.1/24',
       ipv6: ['10:1:1::1/127'],
       addr_method: 'loopback',
@@ -158,6 +159,10 @@ describe provider_class do
     context 'link speed options' do
       subject { confighash['config']['link-speed'] }
       it { is_expected.to eq '1000' }
+    end
+    context 'link auto negotiation' do
+      subject { confighash['config']['link-autoneg'] }
+      it { is_expected.to eq 'on' }
     end
     context 'link duplex options' do
       subject { confighash['config']['link-duplex'] }

--- a/spec/unit/type/cumulus_interface_spec.rb
+++ b/spec/unit/type/cumulus_interface_spec.rb
@@ -10,6 +10,7 @@ describe cl_iface do
       :alias_name,
       :addr_method,
       :speed,
+      :autoneg,
       :mtu,
       :virtual_ip,
       :virtual_mac,

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -26,6 +26,7 @@ cumulus_interface { 'br0.1':
 }
 cumulus_interface { "swp33":
    speed => 1000,
+   autoneg => 'off',
    alias_name => "trunk port",
    vids => ["1-10", '12'],
    pvid => 1


### PR DESCRIPTION
some links need auto negotiation explicitly turned on while the hardware
default is off