### PR TITLE
Add ability to set forward error correction on interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ cumulus_bridge { 'bridge':
 * `addr_method` - Address assignment method, `dhcp` or `loopback`. Default is empty (no address method is set).
 * `speed` - The interface link speed.
 * `mtu` - The interface Maximum Transmission Unit (MTU).
+* `fec` - Optionally configure Forward Error Correction for an interface, `baser`, `rs` or `off`.
 * `virtual_ip` - VRR virtual IP address.
 * `virtual_mac` - VRR virtual MAC address.
 * `vids` - Array of VLANs to be configured for a VLAN-aware trunk interface.

--- a/lib/cumulus/ifupdown2.rb
+++ b/lib/cumulus/ifupdown2.rb
@@ -123,6 +123,12 @@ class Ifupdown2Config
     @confighash['config']['link-duplex'] = 'full'
   end
 
+  def update_fec
+    return if @resource[:fec].nil?
+    Puppet.debug "configuring fec #{@resource[:name]}"
+    @confighash['config']['link-fec'] = @resource[:fec].to_s
+  end
+
   # updates vrr config in config hash
   def update_vrr
     return if @resource[:virtual_ip].nil?

--- a/lib/puppet/provider/cumulus_interface/cumulus.rb
+++ b/lib/puppet/provider/cumulus_interface/cumulus.rb
@@ -5,6 +5,7 @@ Puppet::Type.type(:cumulus_interface).provide :cumulus do
   def build_desired_config
     config = Ifupdown2Config.new(resource)
     config.update_speed
+    config.update_fec
     config.update_addr_method
     config.update_address
     %w(vids pvid).each do |attr|

--- a/lib/puppet/type/cumulus_interface.rb
+++ b/lib/puppet/type/cumulus_interface.rb
@@ -63,6 +63,10 @@ Puppet::Type.newtype(:cumulus_interface) do
     end
   end
 
+  newparam(:fec) do
+    desc 'configure Forward Error Correction. Valid values are baser, rs and off'
+  end
+
   newparam(:mtu) do
     desc 'link mtu. Can be 1500 to 9000 KBs'
     munge do |value|


### PR DESCRIPTION
These changes add the ability to specify link-fec on interfaces via a new fec paramter for cumulus interfaces.
